### PR TITLE
setup of windows tests execution

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -33,14 +33,14 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-latest
-            c_compiler: clang
-            cpp_compiler: clang++
+#          - os: ubuntu-latest
+#            c_compiler: clang
+#            cpp_compiler: clang++
         exclude:
           - os: windows-latest
             c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
+#          - os: windows-latest
+#            c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
 
@@ -83,17 +83,3 @@ jobs:
       shell: cmd
       run: .\testbpatch.exe
 
-    - name: Integration Tests on Ubuntu
-      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      if: matrix.os=='ubuntu-latest'
-      working-directory: ${{ github.workspace }}/IntegrationTests/
-      run: ./in_tests.sh ${{ steps.strings.outputs.build-output-dir }}/bpatch
-
-    - name: Integration Tests on Windows
-      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      if: matrix.os=='windows-latest'
-      working-directory:  ${{ github.workspace }}/IntegrationTests/
-      shell: cmd
-      run: in_tests.cmd ${{ steps.strings.outputs.build-output-dir }}\${{ matrix.build_type }}\testbpatch.exe

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release, Debug]
-        c_compiler: [gcc, cl, clang] #clang, has errors for a while
+        c_compiler: [gcc, cl] #note: clang 14.0.0 and ranges seems are not friends yet  (clang skipped)
         include:
           - os: windows-latest
             c_compiler: cl
@@ -33,14 +33,14 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-latest
-            c_compiler: clang
-            cpp_compiler: clang++
+#          - os: ubuntu-latest
+#            c_compiler: clang       #no member named 'equal', 'any_of', 'find_if' in namespace 'std::ranges' for clang yet
+#            cpp_compiler: clang++
         exclude:
           - os: windows-latest
             c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
+#          - os: windows-latest
+#            c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -79,5 +79,5 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       if: matrix.os=='windows-latest'
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}/testbpatch/${{ matrix.build_type }}/
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}\testbpatch\${{ matrix.build_type }}\
       run: testbpatch.exe

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release, Debug]
-        c_compiler: [gcc, clang, cl]
+        c_compiler: [gcc, cl] #clang, has errors for a while
         include:
           - os: windows-latest
             c_compiler: cl
@@ -68,17 +68,32 @@ jobs:
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
-    - name: Test on Ubuntu
+    - name: Unit Tests on Ubuntu
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       if: matrix.os=='ubuntu-latest'
       working-directory: ${{ steps.strings.outputs.build-output-dir }}/testbpatch/
       run: ./testbpatch
-      
-    - name: Test on Windows
+
+    - name: Unit Tests on Windows
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       if: matrix.os=='windows-latest'
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}/testbpatch/${{ matrix.build_type }}\
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}/testbpatch/${{ matrix.build_type }}/
       shell: cmd
       run: .\testbpatch.exe
+
+    - name: Integration Tests on Ubuntu
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      if: matrix.os=='ubuntu-latest'
+      working-directory: ${{ github.workspace }}/IntegrationTests/
+      run: ./in_tests.sh ${{ steps.strings.outputs.build-output-dir }}/bpatch
+
+    - name: Integration Tests on Windows
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      if: matrix.os=='windows-latest'
+      working-directory:  ${{ github.workspace }}/IntegrationTests/
+      shell: cmd
+      run: in_tests.cmd ${{ steps.strings.outputs.build-output-dir }}\${{ matrix.build_type }}\testbpatch.exe

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release, Debug]
-        c_compiler: [gcc, cl] #clang, has errors for a while
+        c_compiler: [gcc, cl, clang] #clang, has errors for a while
         include:
           - os: windows-latest
             c_compiler: cl
@@ -33,14 +33,14 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-#          - os: ubuntu-latest
-#            c_compiler: clang
-#            cpp_compiler: clang++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
         exclude:
           - os: windows-latest
             c_compiler: gcc
-#          - os: windows-latest
-#            c_compiler: clang
+          - os: windows-latest
+            c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -79,5 +79,6 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       if: matrix.os=='windows-latest'
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}\testbpatch\${{ matrix.build_type }}\
-      run: testbpatch.exe
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}/testbpatch/${{ matrix.build_type }}\
+      shell: cmd
+      run: .\testbpatch.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,8 @@ else()
     message(FATAL_ERROR "Unsupported compiler")
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fexperimental-library")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # note Clang 14.0.0 and ranges seems are not friends yet
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
 message(STATUS "CMAKE_CXX_FLAGS:" ${CMAKE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fexperimental-library")
 endif()
 
 message(STATUS "CMAKE_CXX_FLAGS:" ${CMAKE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ else()
     message(FATAL_ERROR "Unsupported compiler")
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # note Clang 14.0.0 and ranges seems are not friends yet
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") #note: Clang 14.0.0 and ranges seems are not friends yet
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 else()
     message(FATAL_ERROR "Unsupported compiler")
 endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 message(STATUS "CMAKE_CXX_FLAGS:" ${CMAKE_CXX_FLAGS})
 
 # Set Release and Debug configurations

--- a/srcbpatch/actionscollection.cpp
+++ b/srcbpatch/actionscollection.cpp
@@ -157,7 +157,7 @@ void ActionsCollection::OnJsonObjectBegins(TJSONObject* const pJson)
 {
     if (0 == replaceSV.compare(pJson->name_) && pJson->level_ == levelReplaceIn)
     {
-        replaces_.emplace_back(std::move(VectorStringviewPairs()));
+        replaces_.emplace_back(VectorStringviewPairs());
     }
 }
 
@@ -173,7 +173,7 @@ void ActionsCollection::OnJsonObjectParsed(TJSONObject* const pJson)
         }
 
         if (const bool added = dictionary_.AddBinaryLexeme(pJson->name_,
-                std::move(AbstractBinaryLexeme::LexemeFromStringView(value)));
+                AbstractBinaryLexeme::LexemeFromStringView(value));
             !added)
         {// overwritten
             ReportDuplicateNameError(pJson->name_);
@@ -206,7 +206,7 @@ void ActionsCollection::OnJsonObjectParsed(TJSONObject* const pJson)
 
         // create binary lexeme from readed data
         if (const bool added = dictionary_.AddBinaryLexeme(pJson->name_,
-            move(AbstractBinaryLexeme::LexemeFromVector(move(adata))));
+            AbstractBinaryLexeme::LexemeFromVector(move(adata)));
             !added)
         {// overwritten
             ReportDuplicateNameError(pJson->name_);
@@ -242,7 +242,7 @@ void ActionsCollection::OnJsonArrayParsed(TJSONObject* const pJson)
                 "Expecting only values [0..255] in \"decimal\" dictionarys");
 
         if (const bool added = dictionary_.AddBinaryLexeme(pJson->name_,
-            std::move(AbstractBinaryLexeme::LexemeFromStringView(value)));
+            AbstractBinaryLexeme::LexemeFromStringView(value));
             !added)
         {// overwritten
             ReportDuplicateNameError(pJson->name_);
@@ -257,7 +257,7 @@ void ActionsCollection::OnJsonArrayParsed(TJSONObject* const pJson)
                 "Expecting only string values [00..FF] in \"hexadecimal\" dictionarys");
 
         if (const bool added = dictionary_.AddBinaryLexeme(pJson->name_,
-            std::move(AbstractBinaryLexeme::LexemeFromStringView(value)));
+            AbstractBinaryLexeme::LexemeFromStringView(value));
             !added)
         {// overwritten
             ReportDuplicateNameError(pJson->name_);
@@ -267,9 +267,7 @@ void ActionsCollection::OnJsonArrayParsed(TJSONObject* const pJson)
 
     if (IsCompositeArray(pJson))
     {
-        composites_.emplace_back(pJson->name_,
-            std::move(
-                ParseArray(pJson, "Composite lexemes can contain only names")));
+        composites_.emplace_back(pJson->name_, ParseArray(pJson, "Composite lexemes can contain only names"));
         return;
     }
 }

--- a/srcbpatch/actionscollection.cpp
+++ b/srcbpatch/actionscollection.cpp
@@ -15,8 +15,7 @@ namespace bpatch
 namespace
 {
 
-    constexpr const size_t levelTodo = 1;
-    constexpr const size_t levelDictionary = 1;
+    constexpr const size_t levelBase = 1; // dictionary, todo
 
     constexpr const size_t levelReplaceIn = 3;
 
@@ -30,7 +29,7 @@ namespace
 template <const std::string_view& sv1>
 bool JsonAtLevel1(TJSONObject* const pJson)
 {
-    return (1 == pJson->level_ &&
+    return (levelBase == pJson->level_ &&
         0 == sv1.compare(pJson->name_));
 };
 

--- a/srcbpatch/binarylexeme.cpp
+++ b/srcbpatch/binarylexeme.cpp
@@ -30,13 +30,13 @@ vector<char> CreateVectorWithData(const char* const pData, const size_t sz)
 
 unique_ptr<AbstractBinaryLexeme> AbstractBinaryLexeme::LexemeFromStringView(const string_view asrc)
 {
-    return LexemeFromVector(move(CreateVectorWithData(asrc.data(), asrc.size())));
+    return LexemeFromVector(CreateVectorWithData(asrc.data(), asrc.size()));
 }
 
 
 unique_ptr<AbstractBinaryLexeme> AbstractBinaryLexeme::LexemeFromSpan(const span<const char> asrc)
 {
-    return LexemeFromVector(move(CreateVectorWithData(asrc.data(), asrc.size())));
+    return LexemeFromVector(CreateVectorWithData(asrc.data(), asrc.size()));
 }
 
 


### PR DESCRIPTION
removed clang - Clang 14.0.0 and ranges seems are not friends yet;
because of clang were found and fixed:
- moving a temporary object prevents copy elision when using RVO. Fixed;
- unused variables have been removed;