### PR TITLE
Added clang-17 support on ubuntu-latest in Github Actions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -21,14 +21,16 @@ jobs:
       # 2. <Windows, Debug, latest MSVC compiler toolchain on the default runner image, default generator>
       # 3. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
       # 4. <Linux, Debug, latest GCC compiler toolchain on the default runner image, default generator>
-      # 5. <MacOS, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      # 6. <MacOS, Debug, latest Clang compiler toolchain on the default runner image, default generator>
+      # 5. <Linux, Release, clang-17 compiler toolchain, default generator>
+      # 6. <Linux, Debug, clang-17 compiler toolchain, default generator>
+      # 7. <MacOS, Release, latest Apple Clang compiler toolchain on the default runner image, default generator>
+      # 8. <MacOS, Debug, latest Apple Clang compiler toolchain on the default runner image, default generator>
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
         build_type: [Release, Debug]
-        c_compiler: [gcc, cl, clang]
+        c_compiler: [gcc, cl, clang, clang-17]
         include:
           - os: windows-latest
             c_compiler: cl
@@ -36,6 +38,9 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang-17
+            cpp_compiler: clang++-17
           - os: macos-14
             c_compiler: clang
             cpp_compiler: clang++
@@ -44,6 +49,8 @@ jobs:
             c_compiler: gcc
           - os: windows-latest
             c_compiler: clang
+          - os: windows-latest
+            c_compiler: clang-17
           - os: ubuntu-latest
             c_compiler: cl
           - os: ubuntu-latest
@@ -52,9 +59,21 @@ jobs:
             c_compiler: cl
           - os: macos-14
             c_compiler: gcc
+          - os: macos-14
+            c_compiler: clang-17
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install clang-17
+      if: matrix.os=='ubuntu-latest' && matrix.c_compiler=='clang-17'
+      run: |
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+        sudo apt-add-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
+        sudo apt-add-repository deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
+        sudo apt-get update
+        sudo apt-get install -y clang-17
+        sudo apt-get install --no-install-recommends -y libc++-17-dev libc++abi-17-dev
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,6 @@ set(pname bpatch)
 set(wild_library wildcharacters)
 project(${pname})
 
-##get google test
-include(FetchContent)
-FetchContent_Declare(googletest
-    GIT_REPOSITORY https://github.com/google/googletest
-    GIT_TAG release-1.12.1)
-FetchContent_GetProperties(googletest)
-#googletest_POPULATED
-#googletest_SOURCE_DIR
-#googletest_BUILD_DIR
-if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BUILD_DIR})
-endif()
-
 # Set C++ standard to 20
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,20 @@ message(STATUS "CMAKE_CXX_FLAGS:" ${CMAKE_CXX_FLAGS})
 # Set Release and Debug configurations
 set(CMAKE_CONFIGURATION_TYPES "Release;Debug" CACHE STRING "Configurations" FORCE)
 
+##get google test
+include(FetchContent)
+FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest
+        GIT_TAG release-1.12.1)
+FetchContent_GetProperties(googletest)
+#googletest_POPULATED
+#googletest_SOURCE_DIR
+#googletest_BUILD_DIR
+if(NOT googletest_POPULATED)
+    FetchContent_Populate(googletest)
+    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BUILD_DIR})
+endif()
+
 include_directories(${wild_library})
 include_directories(src${pname})
 

--- a/testbpatch/CMakeLists.txt
+++ b/testbpatch/CMakeLists.txt
@@ -7,14 +7,6 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include(FetchContent)
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest
-        GIT_TAG release-1.12.1)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
 
 # Source files
 set(SOURCE_FILES

--- a/testbpatch/CMakeLists.txt
+++ b/testbpatch/CMakeLists.txt
@@ -7,6 +7,14 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest
+        GIT_TAG release-1.12.1)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 # Source files
 set(SOURCE_FILES


### PR DESCRIPTION
* clang 17 support has been added for ubuntu compilation
* gtest part of CMakeLists.txt moved into appropriate place inside file