### PR TITLE
memcpy included in cstring - added include

### DIFF
--- a/srcbpatch/dictionarykeywords.cpp
+++ b/srcbpatch/dictionarykeywords.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "dictionarykeywords.h"
 
 namespace bpatch

--- a/srcbpatch/processing.cpp
+++ b/srcbpatch/processing.cpp
@@ -1,10 +1,10 @@
+#include "stdafx.h"
 #include "actionscollection.h"
 #include "binarylexeme.h"
 #include "bpatchfolders.h"
 #include "consoleparametersreader.h"
 #include "fileprocessing.h"
 #include "processing.h"
-#include "stdafx.h"
 #include "timemeasurer.h"
 #include "wildcharacters.h"
 

--- a/srcbpatch/stdafx.h
+++ b/srcbpatch/stdafx.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <filesystem>
 #include <future>


### PR DESCRIPTION
<cstring> include has been added in stdafx.h - memcpy defined in this include according standard 