### PR TITLE
added a test for LexemeOf1 with negative value

### DIFF
--- a/testbpatch/test.cpp
+++ b/testbpatch/test.cpp
@@ -761,14 +761,15 @@ TEST(ACollection, ActionsProcessing)
 
 
 /// <summary>
-///   check that we process LexemeOf1 with negative value correctly
+///   Check processing for the full range of characters inside LexemeOf1 class.
 /// </summary>
 ///
-TEST(ACollection, IndexCastText)
+TEST(ACollection, LexemeOf1Test)
 {
+
     TestData arrTests[] = {
         {
-        R"(
+    R"(
             {"dictionary":{
                            "hexadecimal":{"someHex":["AB"], "minusOne":["FF"]}
                           },
@@ -779,8 +780,8 @@ TEST(ACollection, IndexCastText)
                 }
             ]}
         )",
-        { "\xFF\xFF", 2 },
-        { "\xAB\xAB", 2 }
+            { "\xFF\xFF", 2 },
+            { "\xAB\xAB", 2 }
         },
         {
     R"(
@@ -796,7 +797,39 @@ TEST(ACollection, IndexCastText)
         )",
     { "\xAD\xFF", 2 },
     { "\xFF\xAB", 2 }
-        }
+        },
+{
+    R"(
+            {"dictionary":{
+                           "hexadecimal":{"zero":["00"], "one":["01"], "minusOne":["FF"], "minusTwo" : ["FE"], "two":["02"], "EE" : ["EE"]}
+                          },
+             "todo":
+            [
+                {
+                    "replace": {"zero": "minusTwo", "one": "minusOne", "minusTwo": "zero", "minusOne": "one", "two": "EE", "EE": "two"}
+                }
+            ]}
+        )",
+    { "\x00\x01\x02\xFF\xFE\xEE", 6 },
+    { "\xFE\xFF\xEE\x01\x00\x02", 6 }
+        },
+{
+    R"(
+            {"dictionary":{
+                           "decimal":{"zero":["0"], "one":["1"], "onetwosix":["126"],
+ "onetwoseven":["127"], "onetwoeight":["128"], "onetwonine":["129"], "twofivefour":["254"], "twofivefive":["255"] }
+                          },
+             "todo":
+            [
+                {
+                    "replace": {"zero": "twofivefive", "one": "twofivefour", "onetwosix": "onetwonine", "onetwoseven": "onetwoeight",
+"onetwoeight": "onetwoseven", "onetwonine": "onetwosix", "twofivefour": "one", "twofivefive": "zero"}
+                }
+            ]}
+        )",
+    { "\x00\x01\x7E\x7F\x80\x81\xFE\xFF", 8 },
+    { "\xFF\xFE\x81\x80\x7F\x7E\x01\x00", 8 }
+}
     };
     for (auto& tst : arrTests)
     {


### PR DESCRIPTION
In the original code, I encountered the following line:
`const size_t index = static_cast<size_t>(*(reinterpret_cast<const unsigned char*>(alpair.first->access().data())));`
I aimed to simplify it and came up with the following:
`const size_t index = static_cast<size_t>(alpair.first->access().front());`
All the tests passed with the simplified code, but they shouldn't have. The reason lies in how the conversion from char to size_t behaves when the char value is negative.

Consider the following example to illustrate the issue more clearly:
`char symbol = -1;`
`const size_t index = static_cast<size_t>(*(reinterpret_cast<const unsigned char*>(&symbol))); // Here, index will be 255`
`const size_t index = static_cast<size_t>(symbol);  // Here, index will be 18446744073709551615 (on a typical 64-bit system)`

So I added a test to cover this specific scenario, ensuring that negative char values are correctly handled in the calculation of "index".